### PR TITLE
Update encoding_check.sh make quicker fix whitespace

### DIFF
--- a/release/src/router/www/encoding_check.sh
+++ b/release/src/router/www/encoding_check.sh
@@ -1,6 +1,2 @@
 #!/bin/sh
-find -name "*.asp" | xargs enca -L none > en_result.txt
-find -name "*.htm" | xargs enca -L none >> en_result.txt
-find -name "*.js" | xargs enca -L none >> en_result.txt
-find -name "*.dict" | xargs enca -L none >> en_result.txt
-
+find . \( -name "*.asp" -o -name "*.htm" -o -name "*.js" -o -name "*.dict" \) -print0 | xargs -0 enca -L none > en_result.txt


### PR DESCRIPTION
When a file has space or special chars in a name xargs uses for example My File.txt it will be recognized as two files by xargs as I understand it. This also makes the encoding check more efficent by using atomic writes and a single line of code. 

So it will see My File.txt as:
My <----- This would be the first file
File.txt <----- This would be the second file

Alternatively to prevent this you could do the following if you have a reason to do 4 separate checks. 

```
find -name "*.asp" -print0 | xargs -0 enca -L none > en_result.txt 
find -name "*.htm" -print0 | xargs -0 enca -L none >> en_result.txt 
find -name "*.js" -print0 | xargs -0 enca -L none >> en_result.txt 
find -name "*.dict" -print0 | xargs -0 enca -L none >> en_result.txt
```

but you will lose the effiency from what I understand but it will fix the whitespace/special char issue by using null termination separators so it don't see multiple files from one file.